### PR TITLE
MemryX v1.2 support added

### DIFF
--- a/aiserver/Dockerfile
+++ b/aiserver/Dockerfile
@@ -130,7 +130,7 @@ RUN apt update && apt install -y linux-headers-generic && \
     echo 'deb [signed-by=/etc/apt/keyrings/memryx.asc] https://developer.memryx.com/deb stable main' | tee /etc/apt/sources.list.d/memryx.list >/dev/null && \
     apt update 
 
-RUN --mount=type=tmpfs,target=/sys/bus/pci apt install -y memx-drivers=1.1.5-3.1 memx-accl=1.1.3-1.1
+RUN --mount=type=tmpfs,target=/sys/bus/pci apt install -y memx-drivers=1.2.1-3.1 memx-accl=1.2.3-1
 
 
 # DXRT installation


### PR DESCRIPTION
Dockerfile changed to require driver & runtime libs v1.2 libs 