### PR TITLE
axelera install update to use install-runtime

### DIFF
--- a/aiserverax/Dockerfile
+++ b/aiserverax/Dockerfile
@@ -37,13 +37,12 @@ RUN if [ -z "${DG_CUSTOM_WHEEL}" ] ; then \
     fi \
     && mkdir -p /zoo
 
-# Extract Axelera version from PySDK installation
-# This is all done in a single RUN step to preserve the value of AXELERA_VERSION
+# Install Axelera runtime using degirum install-runtime command and required system packages
 RUN echo "Starting Axelera installation" >> /buildLog.txt && \
     degirum install-runtime axelera && \
     # Metis driver installation skipped in docker image
     # Pciutils and kmod are required if metis driver is not installed
-    apt install -y pciutils kmod && \
+    apt update && apt install -y pciutils kmod && \
     echo "Axelera installation completed" >> /buildLog.txt
     
 

--- a/aiserverax/Dockerfile
+++ b/aiserverax/Dockerfile
@@ -40,36 +40,11 @@ RUN if [ -z "${DG_CUSTOM_WHEEL}" ] ; then \
 # Extract Axelera version from PySDK installation
 # This is all done in a single RUN step to preserve the value of AXELERA_VERSION
 RUN echo "Starting Axelera installation" >> /buildLog.txt && \
-    SITE_PACKAGES=$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))") && \
-    AXELERA_VERSION=$(find "$SITE_PACKAGES" -type f -name 'libaxelera_runtime_agent--*.dgp' \
-        | sed -n 's/.*libaxelera_runtime_agent--\([0-9.]*\)\.dgp$/\1/p') && \
-# Axelera installation
-    if [ -n "$AXELERA_VERSION" ]; then \
-        echo "Found AXELERA_VERSION=$AXELERA_VERSION, proceeding with installation" >> /buildLog.txt; \
-        GPG_URL="https://software.axelera.ai/artifactory/api/security/keypair/axelera/public" && \
-        GPG_KEY_PATH="/etc/apt/keyrings/axelera.gpg" && \
-        REPO_LIST_PATH="/etc/apt/sources.list.d/axelera.list" && \
-        REPO_SOURCE="https://software.axelera.ai/artifactory/axelera-apt-source/ stable main" && \
-        mkdir -p "$(dirname "$GPG_KEY_PATH")" && \
-        curl -fsSL "$GPG_URL" | gpg --dearmor | tee "$GPG_KEY_PATH" > /dev/null && \
-        chmod 644 "$GPG_KEY_PATH" && \
-        echo "deb [signed-by=$GPG_KEY_PATH] $REPO_SOURCE" | tee "$REPO_LIST_PATH" > /dev/null && \
-        apt update && \
-        # Metis driver installation skipped in docker image
-        # Pciutils and kmod are required if metis driver is not installed
-        apt install -y \
-            axelera-runtime-$AXELERA_VERSION \
-            axelera-device-$AXELERA_VERSION \
-            axelera-riscv-gnu-newlib-toolchain-409b951ba662-7 \
-            pciutils \
-            kmod && \
-        # Write runtime library path to ldconfig's configuration directory instead of LD_LIBRARY_PATH
-        echo "/opt/axelera/runtime-$AXELERA_VERSION-1/lib" > /etc/ld.so.conf.d/axelera.conf && \
-        ldconfig && \
-        echo "Axelera installation completed" >> /buildLog.txt; \
-    else \
-        echo "Axelera version not found, skipping installation" >> /buildLog.txt; \
-    fi
+    degirum install-runtime axelera && \
+    # Metis driver installation skipped in docker image
+    # Pciutils and kmod are required if metis driver is not installed
+    apt install -y pciutils kmod && \
+    echo "Axelera installation completed" >> /buildLog.txt
     
 
 # Cleanup / remove unnecessary files


### PR DESCRIPTION
updated aiserverax to use the new "degirum install-runtime axelera" api instead of explicit manual package install