### PR TITLE
aiserver Dockerfile for DeepX runtime 3.1.0

### DIFF
--- a/aiserver/Dockerfile
+++ b/aiserver/Dockerfile
@@ -133,7 +133,8 @@ COPY ${LIBDXRT_DEB} /tmp/libdxrt.deb
 RUN echo "Starting DXRT installation if applicable" >> /buildLog.txt && \
     if [ "${LIBDXRT_DEB}" != "dummy.deb" ]; then \
         echo "DXRT deb specified, proceeding with installation" >> /buildLog.txt; \
-        apt-get update && apt-get install -y unzip git cmake ninja-build python3-dev python3-pybind11 wget && \
+        apt-get update && apt-get install -y unzip git cmake ninja-build python3-dev python3-pybind11 wget \
+        libncurses-dev && \ 
         dpkg --unpack /tmp/libdxrt.deb && \
         DEBIAN_FRONTEND=noninteractive dpkg --configure -a --debug=2 || true && \
         echo "DXRT installation completed" >> /buildLog.txt; \


### PR DESCRIPTION
Installation of curses (libncurses-dev) is added to aiserverDockerfile